### PR TITLE
Fetch Pull Request info only when workspace is a GitHub Repository

### DIFF
--- a/lib/pr-linter.coffee
+++ b/lib/pr-linter.coffee
@@ -164,4 +164,4 @@ module.exports = new class # This only needs to be a class to bind lint()
 
         # Filter out all the comments that no longer apply since the source was changed
         allMessages = allMessages.concat(lintWarningsOrNull.filter (lintWarning) -> !!lintWarning)
-    @linter?.setMessages(allMessages)
+    @linter.setMessages(allMessages)


### PR DESCRIPTION
Previously, this plugin assumed the workspace was always a GitHub Repository and would try to fetch information which led to errors when working in a directory that was not in GitHub.

This should resolve issue #5