### PR TITLE
use keytar package for storing the API key

### DIFF
--- a/lib/dialog.coffee
+++ b/lib/dialog.coffee
@@ -1,0 +1,81 @@
+# From https://github.com/sveale/remote-edit
+{$, $$, View, TextEditorView} = require 'atom-space-pen-views'
+{CompositeDisposable} = require 'atom'
+
+TOKEN_RE = /^[a-f0-9]{40}/
+NEW_TOKEN_URL = 'https://github.com/settings/tokens'
+
+module.exports =
+class Dialog extends View
+  @content: ({title, detail} = {}) ->
+    @div class: 'dialog', =>
+      @h1 title
+      @p detail
+      @hr()
+      @p 'You can create a token from the following link and then use it here. It should be a string of 40 hex characters. The token will be saved in your keychain/keyring (using https://github.com/atom/node-keytar).'
+      @div =>
+        @a NEW_TOKEN_URL, href: NEW_TOKEN_URL
+      @hr()
+      @label 'Enter Token (or leave blank) and press Enter', class: 'icon', outlet: 'promptText'
+      @subview 'miniEditor', new TextEditorView(mini: true)
+      @div class: 'error-message', outlet: 'errorMessage'
+
+  initialize: ({iconClass, defaultValue} = {}) ->
+    @promptText.addClass(iconClass) if iconClass
+
+    @disposables = new CompositeDisposable
+    @disposables.add atom.commands.add 'atom-workspace',
+      'core:confirm': => @onConfirm(@miniEditor.getText())
+      'core:cancel': (event) =>
+        @cancel()
+        event.stopPropagation()
+
+    @miniEditor.setText(defaultValue)
+    @miniEditor.getModel().onDidChange => @validate()
+    # @miniEditor.on 'blur', => @cancel()
+
+  onConfirm: (value) ->
+    @callback?(undefined, value)
+    @cancel()
+    value
+
+  validate: () ->
+    token = @miniEditor.getText()
+    if token and not TOKEN_RE.test(token)
+      @showError('Invalid format. Token must be a string of 40 hex characters')
+
+  showError: (message='') ->
+    @errorMessage.text(message)
+    @flashError() if message
+
+  destroy: ->
+    @disposables.dispose()
+
+  cancel: ->
+    @cancelled()
+    @restoreFocus()
+    @destroy()
+
+  cancelled: ->
+    @hide()
+
+  toggle: (@callback) ->
+    if @panel?.isVisible()
+      @cancel()
+    else
+      @show()
+
+  show: () ->
+    @panel ?= atom.workspace.addModalPanel(item: this)
+    @panel.show()
+    @storeFocusedElement()
+    @miniEditor.focus()
+
+  hide: ->
+    @panel?.hide()
+
+  storeFocusedElement: ->
+    @previouslyFocusedElement = $(document.activeElement)
+
+  restoreFocus: ->
+    @previouslyFocusedElement?.focus()

--- a/lib/dialog.coffee
+++ b/lib/dialog.coffee
@@ -12,7 +12,7 @@ class Dialog extends View
       @h1 title
       @p detail
       @hr()
-      @p 'You can create a token from the following link and then use it here. It should be a string of 40 hex characters. The token will be saved in your keychain/keyring (using https://github.com/atom/node-keytar).'
+      @p 'You can create a token from the following link and then enter it below. The token will be saved in your keychain/keyring (using https://github.com/atom/node-keytar).'
       @div =>
         @a NEW_TOKEN_URL, href: NEW_TOKEN_URL
       @hr()
@@ -30,7 +30,8 @@ class Dialog extends View
         @cancel()
         event.stopPropagation()
 
-    @miniEditor.setText(defaultValue)
+    if defaultValue
+      @miniEditor.setText(defaultValue)
     @miniEditor.getModel().onDidChange => @validate()
     # @miniEditor.on 'blur', => @cancel()
 
@@ -43,6 +44,8 @@ class Dialog extends View
     token = @miniEditor.getText()
     if token and not TOKEN_RE.test(token)
       @showError('Invalid format. Token must be a string of 40 hex characters')
+    else
+      @showError() # Clear the error message
 
   showError: (message='') ->
     @errorMessage.text(message)

--- a/lib/gh-client.coffee
+++ b/lib/gh-client.coffee
@@ -1,12 +1,15 @@
 {CompositeDisposable, Emitter} = require 'atom'
 _ = require 'underscore-plus'
 Octokat = require 'octokat'
+keytar = require 'keytar'
 {getRepoInfo} = require './helpers'
 Polling = require './polling'
+Dialog = require './dialog'
 
 CONFIG_POLLING_INTERVAL = 'pull-requests.githubPollingInterval'
-CONFIG_AUTHORIZATION_TOKEN = 'pull-requests.githubAuthorizationToken'
 CONFIG_ROOT_URL = 'pull-requests.githubRootUrl'
+KEYTAR_SERVICE_NAME = 'GitHub API Token for Atom pull-requests (servicename)'
+KEYTAR_ACCOUNT_NAME = 'GitHub API Token for Atom pull-requests (accountname)'
 
 TOKEN_RE = /^[a-f0-9]{40}/
 
@@ -64,7 +67,6 @@ module.exports = new class GitHubClient
     @configSubscriptions = new CompositeDisposable
 
     @_subscribeConfig CONFIG_POLLING_INTERVAL, => @updatePollingInterval()
-    @_subscribeConfig CONFIG_AUTHORIZATION_TOKEN, => @updateConfig()
     @_subscribeConfig CONFIG_ROOT_URL, => @updateConfig()
 
   _subscribeConfig: (configKey, cb) ->
@@ -96,14 +98,12 @@ module.exports = new class GitHubClient
         return repo
 
   updateConfig: ->
-    token = atom.config.get(CONFIG_AUTHORIZATION_TOKEN) or null
+    token = keytar.findPassword(KEYTAR_SERVICE_NAME, KEYTAR_ACCOUNT_NAME) or null
     rootURL = atom.config.get(CONFIG_ROOT_URL) or null
 
     # Validate the token and URL before instantiating
     if token and not TOKEN_RE.test(token)
-      atom.notifications.addError 'Token format is invalid',
-        dismissable: true
-        detail: 'You can create a token from https://github.com/settings/tokens and then use it here. It should be a string of 40 hex characters'
+      keytar.deletePassword(KEYTAR_SERVICE_NAME, KEYTAR_ACCOUNT_NAME)
       token = null
 
     @URL_TEST_NODE.href = rootURL
@@ -198,6 +198,19 @@ module.exports = new class GitHubClient
               atom.notifications.addError 'Rate limit exceeded for talking to GitHub API',
                 dismissable: true
                 detail: 'You have exceeded the rate limit for anonymous access to the GitHub API. You will need to wait an hour or create a token from https://github.com/settings/tokens and add it to the settings for the pull-requests plugin'
+
+              tokenDialog = new Dialog({
+                defaultValue: keytar.getPassword(KEYTAR_SERVICE_NAME, KEYTAR_ACCOUNT_NAME)
+                title: 'Rate limit exceeded for talking to GitHub API'
+                detail: 'You have exceeded the rate limit for anonymous access to the GitHub API. You will need to wait an hour or create a token using the instructions below.'})
+              tokenDialog.toggle (err, token) =>
+                unless err
+                  if token
+                    @hasShownConnectionError = false
+                    if keytar.getPassword(KEYTAR_SERVICE_NAME, KEYTAR_ACCOUNT_NAME)
+                      keytar.replacePassword(KEYTAR_SERVICE_NAME, KEYTAR_ACCOUNT_NAME, token)
+                    else
+                      keytar.addPassword(KEYTAR_SERVICE_NAME, KEYTAR_ACCOUNT_NAME, token)
               # yield [] so consumers still run
               return []
           catch error
@@ -205,6 +218,19 @@ module.exports = new class GitHubClient
           atom.notifications.addError 'Error fetching Pull Request data from GitHub',
             dismissable: true
             detail: 'Make sure you are connected to the internet and if this is a private repository then you will need to create a token from https://github.com/settings/tokens and provide it to the pull-requests plugin settings'
+
+          tokenDialog = new Dialog({
+            defaultValue: keytar.getPassword(KEYTAR_SERVICE_NAME, KEYTAR_ACCOUNT_NAME)
+            title: 'Unable to find repository on GitHub'
+            detail: 'Make sure you are connected to the internet and if this is a private repository then you will need to create a token using the instructions below. If you already have a token entered then it may not have the correct scope. If this is a private repository then make sure the "repo" scope is selected.'})
+          tokenDialog.toggle (err, token) =>
+            unless err
+              if token
+                @hasShownConnectionError = false
+                if keytar.getPassword(KEYTAR_SERVICE_NAME, KEYTAR_ACCOUNT_NAME)
+                  keytar.replacePassword(KEYTAR_SERVICE_NAME, KEYTAR_ACCOUNT_NAME, token)
+                else
+                  keytar.addPassword(KEYTAR_SERVICE_NAME, KEYTAR_ACCOUNT_NAME, token)
 
         # yield [] so consumers still run
         []

--- a/lib/gh-client.coffee
+++ b/lib/gh-client.coffee
@@ -188,7 +188,7 @@ module.exports = new class GitHubClient
       @_fetchComments()
       .then (comments) =>
         @emitter.emit('did-update', comments)
-      .then undefined, (err) ->
+      .then undefined, (err) =>
         unless @hasShownConnectionError
           @hasShownConnectionError = true
           try
@@ -211,6 +211,7 @@ module.exports = new class GitHubClient
                       keytar.replacePassword(KEYTAR_SERVICE_NAME, KEYTAR_ACCOUNT_NAME, token)
                     else
                       keytar.addPassword(KEYTAR_SERVICE_NAME, KEYTAR_ACCOUNT_NAME, token)
+                  @updateConfig()
               # yield [] so consumers still run
               return []
           catch error
@@ -231,6 +232,7 @@ module.exports = new class GitHubClient
                   keytar.replacePassword(KEYTAR_SERVICE_NAME, KEYTAR_ACCOUNT_NAME, token)
                 else
                   keytar.addPassword(KEYTAR_SERVICE_NAME, KEYTAR_ACCOUNT_NAME, token)
+              @updateConfig()
 
         # yield [] so consumers still run
         []

--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
   },
   "dependencies": {
     "atom-package-deps": "^2.0.3",
+    "atom-space-pen-views": "^2.2.0",
     "fs-plus": "^2.8.1",
     "gfm-linkify": "^0.1.0",
+    "keytar": "^3.0.2",
     "octokat": "^0.4.13",
     "ultramarked": "^1.7.0",
     "underscore-plus": "^1.6.6"


### PR DESCRIPTION
This opens a dialog prompting the user to enter an API token when the rate limit is reached or when a repository cannot be found (probably private).

It then stores the API key in the OS keychain/keyring (using [atom/node-keytar](https://github.com/atom/node-keytar) ) instead of Atom's `config.cson` which is included when reporting errors.

fixes #20

# Screenshot

![image](https://cloud.githubusercontent.com/assets/253202/21531377/a38146b0-cd15-11e6-8a13-fe3d97bdc578.png)

# TODO

- [ ] Improve the wording and UI in the dialog
- [ ] remove the now-extraneous error dialogs
- [ ] decide on a keystore service and account name
- [ ] _Maybe_ provide an automatic migration