### PR TITLE
Update KEYTAR_SERVICE_NAME and KEYTAR_ACCOUNT_NAME

### DIFF
--- a/lib/gh-client.coffee
+++ b/lib/gh-client.coffee
@@ -8,8 +8,8 @@ Dialog = require './dialog'
 
 CONFIG_POLLING_INTERVAL = 'pull-requests.githubPollingInterval'
 CONFIG_ROOT_URL = 'pull-requests.githubRootUrl'
-KEYTAR_SERVICE_NAME = 'GitHub API Token for Atom pull-requests (servicename)'
-KEYTAR_ACCOUNT_NAME = 'GitHub API Token for Atom pull-requests (accountname)'
+KEYTAR_SERVICE_NAME = 'atom-github'
+KEYTAR_ACCOUNT_NAME = 'https://api.github.com'
 
 TOKEN_RE = /^[a-f0-9]{40}/
 


### PR DESCRIPTION
This fixes https://github.com/philschatz/atom-pull-requests/issues/33 by setting the `KEYTAR_SERVICE_NAME` and `KEYTAR_ACCOUNT_NAME` to the defaults set by atom in Keychain.app.