### PR TITLE
Update to newer version of atom-package-deps to fix breaking changes in dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     }
   },
   "dependencies": {
-    "atom-package-deps": "^2.0.3",
+    "atom-package-deps": "^4.6.2",
     "atom-space-pen-views": "^2.2.0",
     "fs-plus": "^2.8.1",
     "gfm-linkify": "^0.1.0",


### PR DESCRIPTION
This fixes https://github.com/philschatz/atom-pull-requests/issues/30 by updating the downstream dep to the latest version. atom-package-deps had breaking changes in v2.0.x.